### PR TITLE
Tmf632 Support

### DIFF
--- a/examples/create_individual.rs
+++ b/examples/create_individual.rs
@@ -1,0 +1,17 @@
+//! Create Individual Example
+
+use tmflib::tmf632::individual_v4::Individual;
+use tmf_client::{Operations, TMFClient};
+use tmf_client::common::tmf_error::TMFError;
+
+fn main() -> Result<(),TMFError> {
+    let individual = Individual::new("John Quinten Citizen");
+
+    let mut client = TMFClient::new("http://localhost:8000");
+
+    let new_individual = client.tmf632().individual().create(individual)?;
+
+    dbg!(new_individual);
+
+    Ok(())
+}

--- a/examples/get_individual.rs
+++ b/examples/get_individual.rs
@@ -1,0 +1,21 @@
+//! Get Individual Example
+
+use tmf_client::{TMFClient,QueryOptions,Operations};
+use tmf_client::common::tmf_error::TMFError;
+use tmflib::{HasId,HasName};
+
+
+fn main() -> Result<(),TMFError> {
+    let mut client = TMFClient::new("http://localhost:8000");
+
+    let individuals = client
+        .tmf632()
+        .individual()
+        .list(None)?;
+
+    for i in individuals {
+        println!("Name: {} Id: {}, Gender: {}",i.get_name(),i.get_id(),i.gender.unwrap_or("Gender not set".to_string()));
+    }
+
+    Ok(())
+}

--- a/examples/get_individual.rs
+++ b/examples/get_individual.rs
@@ -1,6 +1,6 @@
 //! Get Individual Example
 
-use tmf_client::{TMFClient,QueryOptions,Operations};
+use tmf_client::{TMFClient,Operations};
 use tmf_client::common::tmf_error::TMFError;
 use tmflib::{HasId,HasName};
 

--- a/examples/get_organization.rs
+++ b/examples/get_organization.rs
@@ -1,0 +1,19 @@
+//! Get Organization Example
+
+use tmf_client::common::tmf_error::TMFError;
+use tmf_client::{Operations, TMFClient};
+use tmflib::{HasId,HasName};
+
+fn main() -> Result<(),TMFError> {
+
+    let organizations = TMFClient::new("http://localhost:8000")
+        .tmf632()
+        .organization()
+        .list(None)?;
+
+    for o in organizations {
+        println!("Name: {} , Id: {}",o.get_name(),o.get_id());
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod common;
 use common::tmf_error::TMFError;
 use tmf::tmf620::TMF620;
 use tmf::tmf622::TMF622;
+use tmf::tmf632::TMF632;
 
 use tmflib::HasId;
 
@@ -98,6 +99,7 @@ pub struct TMFClient {
     host : String,
     tmf620 : Option<TMF620>,
     tmf622 : Option<TMF622>,
+    tmf632 : Option<TMF632>,
 }
 
 impl TMFClient {
@@ -111,10 +113,11 @@ impl TMFClient {
             host : host.into(),
             tmf620 : None,
             tmf622 : None,
+            tmf632 : None,
         }
     }
 
-    /// Create access TMF620 API
+    /// Create access to TMF620 API
     /// ```
     /// # use tmf_client::TMFClient;
     /// let tmf620 = TMFClient::new("http://localhost:8000")
@@ -132,7 +135,7 @@ impl TMFClient {
         }
     }
 
-    /// Create access TMF622 API
+    /// Create access to TMF622 API
     /// ```
     /// # use tmf_client::TMFClient;
     /// let tmf620 = TMFClient::new("http://localhost:8000")
@@ -145,6 +148,23 @@ impl TMFClient {
                 // Allocate a new instance
                 let tmf = TMF622::new(self.host.clone());
                 self.tmf622 = Some(tmf.clone());
+                tmf
+            }
+        }
+    }
+
+    /// Create access to TMF632 API
+    /// ```
+    /// # use tmf_client::TMFClient;
+    /// let tmf632 = TMFClient::new("http://localhost:8000")
+    ///     .tmf632();
+    /// ```
+    pub fn tmf632(&mut self) -> TMF632 {
+        match self.tmf632.as_mut() {
+            Some(tmf) => tmf.clone(),
+            None => {
+                let tmf = TMF632::new(self.host.clone());
+                self.tmf632 = Some(tmf.clone());
                 tmf
             }
         }

--- a/src/tmf/mod.rs
+++ b/src/tmf/mod.rs
@@ -1,10 +1,13 @@
 //! TMF Modules
 //! 
 
+use std::io::Read;
+
 use crate::QueryOptions;
 use crate::common::tmf_error::TMFError;
 use tmflib::{HasId,Uri};
-use serde::de::DeserializeOwned;
+use serde::{de::DeserializeOwned, Serialize};
+// use log::info;
 
 pub mod tmf620;
 pub mod tmf622;
@@ -27,16 +30,24 @@ pub fn list_tmf<T : HasId + DeserializeOwned>(host: Uri, filter : Option<QueryOp
         None => String::default(),
     };
     let url = format!("{}{}?{}",host,T::get_class_href(),filter);
-    println!("Filter: {}",filter);
+    // info!("Filter: {}",filter);
     let objects = reqwest::blocking::get(url)?.text()?;
     let output : Vec<T> = serde_json::from_str(objects.as_str())?;
     Ok(output)
 }
 
 /// Create a new TMF object
-pub fn create_tmf<T : HasId + DeserializeOwned>(host : Uri, _item : T) -> Result<T,TMFError> {
-    let _url = format!("{}{}",host,T::get_class_href());
-    Err(TMFError::from("Not implemented yet"))
+pub fn create_tmf<T : HasId + Serialize + DeserializeOwned>(host : Uri, item : T) -> Result<T,TMFError> {
+    let url = format!("{}{}",host,T::get_class_href());
+    let client = reqwest::blocking::Client::new();
+    let body_str = serde_json::to_string(&item)?;
+    let mut res = client.post(url)
+        .body(body_str)
+        .send()?;
+    let mut output = String::default();
+    let _ = res.read_to_string(&mut output);
+    let item : T = serde_json::from_str(output.as_str())?;
+    Ok(item)
 }
 
 /// Update an existing TMF object

--- a/src/tmf/mod.rs
+++ b/src/tmf/mod.rs
@@ -8,6 +8,7 @@ use serde::de::DeserializeOwned;
 
 pub mod tmf620;
 pub mod tmf622;
+pub mod tmf632;
 
 /// Make API call to retrieve a single TMF object
 pub fn get_tmf<T : HasId + DeserializeOwned>(host: Uri, id : String) -> Result<Vec<T>,TMFError> {

--- a/src/tmf/tmf620.rs
+++ b/src/tmf/tmf620.rs
@@ -61,8 +61,8 @@ impl TMF620Catalog {
 impl Operations for TMF620Catalog {
     type TMF = Catalog;
 
-    fn create(&self, _item : Self::TMF) -> Result<Self::TMF,TMFError> {
-        Err(TMFError::from("Not implemented"))    
+    fn create(&self, item : Self::TMF) -> Result<Self::TMF,TMFError> {
+        create_tmf(self.host.clone(), item)   
     }
     fn delete(&self, _id : impl Into<String>) -> Result<Self::TMF,TMFError> {
         Err(TMFError::from("Not implemented"))    
@@ -96,8 +96,8 @@ impl TMF620ProductOffering {
 impl Operations for TMF620ProductOffering {
     type TMF = ProductOffering;
 
-    fn create(&self, _item : Self::TMF) -> Result<Self::TMF,TMFError> {
-        Err(TMFError::from("Not implemented"))    
+    fn create(&self, item : Self::TMF) -> Result<Self::TMF,TMFError> {
+        create_tmf(self.host.clone(), item)    
     }
     fn delete(&self, _id : impl Into<String>) -> Result<Self::TMF,TMFError> {
         Err(TMFError::from("Not implemented"))        
@@ -129,8 +129,8 @@ impl TMF620ProductOfferingPrice {
 impl Operations for TMF620ProductOfferingPrice {
     type TMF = ProductOfferingPrice;
 
-    fn create(&self, _item : Self::TMF) -> Result<Self::TMF,TMFError> {
-        Err(TMFError::from("Not implemented"))    
+    fn create(&self, item : Self::TMF) -> Result<Self::TMF,TMFError> {
+        create_tmf(self.host.clone(), item)    
     }
     fn delete(&self, _id : impl Into<String>) -> Result<Self::TMF,TMFError> {
         Err(TMFError::from("Not implemented"))        
@@ -162,8 +162,8 @@ impl TMF620ProductSpecification {
 impl Operations for TMF620ProductSpecification {
     type TMF = ProductSpecification;
 
-    fn create(&self, _item : Self::TMF) -> Result<Self::TMF,TMFError> {
-        Err(TMFError::from("Not implemented"))    
+    fn create(&self, item : Self::TMF) -> Result<Self::TMF,TMFError> {
+        create_tmf(self.host.clone(), item)  
     }
     fn delete(&self, _id : impl Into<String>) -> Result<Self::TMF,TMFError> {
         Err(TMFError::from("Not implemented"))        

--- a/src/tmf/tmf632.rs
+++ b/src/tmf/tmf632.rs
@@ -2,7 +2,7 @@
 //! 
 
 use tmflib::tmf632::organization_v4::Organization;
-use tmflib::{Uri,HasId,HasName};
+use tmflib::Uri;
 use tmflib::tmf632::individual_v4::Individual;
 use crate::Operations;
 use crate::common::tmf_error::TMFError;
@@ -16,6 +16,7 @@ pub struct TMF632Individual {
     host : Uri,
 }
 
+/// TMF632 Organization
 pub struct TMF632Organization {
     host : Uri,
 }
@@ -33,7 +34,7 @@ impl Operations for TMF632Individual {
     fn create(&self, item : Self::TMF) -> Result<Self::TMF,TMFError> {
         create_tmf(self.host.clone(), item)
     }
-    fn delete(&self, id : impl Into<String>) -> Result<Self::TMF,TMFError> {
+    fn delete(&self, _id : impl Into<String>) -> Result<Self::TMF,TMFError> {
         Err(TMFError::from("Not implemented"))     
     }
     fn get(&self, id : impl Into<String>) -> Result<Vec<Self::TMF>,TMFError> {
@@ -42,7 +43,7 @@ impl Operations for TMF632Individual {
     fn list(&self, filter : Option<crate::QueryOptions>) -> Result<Vec<Self::TMF>,TMFError> {
         list_tmf(self.host.clone(),filter)    
     }
-    fn update(&self, id : impl Into<String>, patch : Self::TMF) -> Result<Self::TMF,TMFError> {
+    fn update(&self, _id : impl Into<String>, _patch : Self::TMF) -> Result<Self::TMF,TMFError> {
         Err(TMFError::from("Not implemented"))     
     }
 }
@@ -60,7 +61,7 @@ impl Operations for TMF632Organization {
     fn create(&self, item : Self::TMF) -> Result<Self::TMF,TMFError> {
         create_tmf(self.host.clone(), item)    
     }
-    fn delete(&self, id : impl Into<String>) -> Result<Self::TMF,TMFError> {
+    fn delete(&self, _id : impl Into<String>) -> Result<Self::TMF,TMFError> {
         Err(TMFError::from("Not implemented"))      
     }
     fn get(&self, id : impl Into<String>) -> Result<Vec<Self::TMF>,TMFError> {
@@ -69,7 +70,7 @@ impl Operations for TMF632Organization {
     fn list(&self, filter : Option<crate::QueryOptions>) -> Result<Vec<Self::TMF>,TMFError> {
         list_tmf(self.host.clone(),filter)    
     }
-    fn update(&self, id : impl Into<String>, patch : Self::TMF) -> Result<Self::TMF,TMFError> {
+    fn update(&self, _id : impl Into<String>, _patch : Self::TMF) -> Result<Self::TMF,TMFError> {
         Err(TMFError::from("Not implemented"))    
     }
 }

--- a/src/tmf/tmf632.rs
+++ b/src/tmf/tmf632.rs
@@ -1,0 +1,79 @@
+//! TMF632 Party
+//! 
+
+use tmflib::{Uri,HasId,HasName};
+use tmflib::tmf632::individual_v4::Individual;
+use crate::Operations;
+use crate::common::tmf_error::TMFError;
+use super::{
+    create_tmf, get_tmf, list_tmf
+};
+
+/// TMF622 Product Order Object
+pub struct TMF632Individual {
+    /// End-point for TMF622
+    host : Uri,
+}
+
+pub struct TMF632Organization {
+    host : Uri,
+}
+
+impl TMF632Individual {
+    /// Create a new instance of Product Order API Object
+    pub fn new(host : Uri) -> TMF632Individual {
+        TMF632Individual{ host }
+    }
+}
+
+impl Operations for TMF632Individual {
+    type TMF = Individual;
+
+    fn create(&self, item : Self::TMF) -> Result<Self::TMF,TMFError> {
+        create_tmf(self.host.clone(), item)
+    }
+    fn delete(&self, id : impl Into<String>) -> Result<Self::TMF,TMFError> {
+        Err(TMFError::from("Not implemented"))     
+    }
+    fn get(&self, id : impl Into<String>) -> Result<Vec<Self::TMF>,TMFError> {
+        get_tmf(self.host.clone(),id.into())    
+    }
+    fn list(&self, filter : Option<crate::QueryOptions>) -> Result<Vec<Self::TMF>,TMFError> {
+        list_tmf(self.host.clone(),filter)    
+    }
+    fn update(&self, id : impl Into<String>, patch : Self::TMF) -> Result<Self::TMF,TMFError> {
+        Err(TMFError::from("Not implemented"))     
+    }
+}
+
+impl TMF632Organization {
+    /// Create a new instance of Product Order API Object
+    pub fn new(host : Uri) -> TMF632Organization {
+        TMF632Organization{ host }
+    }
+}
+
+/// Product Ordering API
+#[derive(Clone,Default,Debug)]
+pub struct TMF632 {
+    host : Uri,
+}
+
+impl TMF632 {
+    /// Create a new instance of TMF622 API
+    pub fn new(host : Uri) -> TMF632 {
+        TMF632 {
+            host
+        }
+    }
+
+    /// Access the order module of TMF622.
+    pub fn individual(&self) -> TMF632Individual {
+        TMF632Individual::new(self.host.clone())
+    }
+
+    /// Create a new Organisation API access object
+    pub fn organization(&self) -> TMF632Organization {
+        TMF632Organization::new(self.host.clone())
+    }
+}

--- a/src/tmf/tmf632.rs
+++ b/src/tmf/tmf632.rs
@@ -1,6 +1,7 @@
 //! TMF632 Party
 //! 
 
+use tmflib::tmf632::organization_v4::Organization;
 use tmflib::{Uri,HasId,HasName};
 use tmflib::tmf632::individual_v4::Individual;
 use crate::Operations;
@@ -50,6 +51,26 @@ impl TMF632Organization {
     /// Create a new instance of Product Order API Object
     pub fn new(host : Uri) -> TMF632Organization {
         TMF632Organization{ host }
+    }
+}
+
+impl Operations for TMF632Organization {
+    type TMF = Organization;
+
+    fn create(&self, item : Self::TMF) -> Result<Self::TMF,TMFError> {
+        create_tmf(self.host.clone(), item)    
+    }
+    fn delete(&self, id : impl Into<String>) -> Result<Self::TMF,TMFError> {
+        Err(TMFError::from("Not implemented"))      
+    }
+    fn get(&self, id : impl Into<String>) -> Result<Vec<Self::TMF>,TMFError> {
+        get_tmf(self.host.clone(),id.into())    
+    }
+    fn list(&self, filter : Option<crate::QueryOptions>) -> Result<Vec<Self::TMF>,TMFError> {
+        list_tmf(self.host.clone(),filter)    
+    }
+    fn update(&self, id : impl Into<String>, patch : Self::TMF) -> Result<Self::TMF,TMFError> {
+        Err(TMFError::from("Not implemented"))    
     }
 }
 


### PR DESCRIPTION
Add support for TMF632 by:

- Add New TMF632 module
- Expand TMFClient to return TMF632 super class
- Add functions to TMF632 super class to return individual or organization sub-classes.