### PR TITLE
Feat: Implement ThisError for errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,12 +1931,13 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tmf-client"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "env_logger",
  "reqwest",
  "serde",
  "serde_json",
+ "thiserror 2.0.11",
  "tmflib",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmf-client"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 authors = ["Ryan Ruckley <rruckley@gmail.com"]
 description = "A Rust client library for TMF conformant APIs"
@@ -25,4 +25,5 @@ env_logger = "0.11.6"
 reqwest = {version = "0.12.12", features = ["blocking","rustls-tls"]}
 serde = "1.0.213"
 serde_json = "1.0.138"
+thiserror = "2.0.11"
 tmflib = "0.1.27"

--- a/src/common/tmf_error.rs
+++ b/src/common/tmf_error.rs
@@ -5,11 +5,11 @@ use thiserror::Error;
 
 #[derive(Debug,Error)]
 pub enum TMFError {
-    #[error("Error: {0}")]
-    NoConnetion(String),
-    #[error("Error: {0}")]
+    #[error("TMFError: {0}")]
+    NoConnection(String),
+    #[error("TMFError: {0}")]
     Unknown(String),
-    #[error("Error: {0}")]
+    #[error("TMFError: {0}")]
     Serialization(String)
 }
 
@@ -21,7 +21,7 @@ impl From<&str> for TMFError {
 
 impl From<reqwest::Error> for TMFError {
     fn from(value: reqwest::Error) -> Self {
-        TMFError::NoConnetion(value.to_string())
+        TMFError::NoConnection(value.to_string())
     }
 }
 
@@ -44,7 +44,7 @@ mod tests {
     fn test_error_from_str() {
         let err = TMFError::from("ThisIsAnError");
 
-        assert_eq!(err.to_string(),"Error: ThisIsAnError".to_string());
+        assert_eq!(err.to_string(),"TMFError: ThisIsAnError".to_string());
     }
 
     #[test]

--- a/src/common/tmf_error.rs
+++ b/src/common/tmf_error.rs
@@ -1,38 +1,39 @@
 
 //! Error Module
 
-#[derive(Debug,Default)]
-pub struct TMFError {
-    pub message : String,
+use thiserror::Error;
+
+#[derive(Debug,Error)]
+pub enum TMFError {
+    #[error("Error: {0}")]
+    NoConnetion(String),
+    #[error("Error: {0}")]
+    Unknown(String),
+    #[error("Error: {0}")]
+    Serialization(String)
 }
 
 impl From<&str> for TMFError {
     fn from(value: &str) -> Self {
-        TMFError {
-            message : value.into(),
-        }
+        TMFError::Unknown(value.to_string())
     }    
 }
 
 impl From<reqwest::Error> for TMFError {
     fn from(value: reqwest::Error) -> Self {
-        TMFError {
-            message : value.to_string(),
-        }
+        TMFError::NoConnetion(value.to_string())
     }
 }
 
 impl From<TMFError> for String {
     fn from(value: TMFError) -> Self {
-        format!("TMFError: {}",value.message)
+        value.to_string()
     }
 }
 
 impl From<serde_json::Error> for TMFError {
     fn from(value: serde_json::Error) -> Self {
-        TMFError {
-            message : value.to_string(),
-        }
+        TMFError::Serialization(value.to_string())
     }
 }
 
@@ -43,14 +44,12 @@ mod tests {
     fn test_error_from_str() {
         let err = TMFError::from("ThisIsAnError");
 
-        assert_eq!(err.message,"ThisIsAnError".to_string());
+        assert_eq!(err.to_string(),"Error: ThisIsAnError".to_string());
     }
 
     #[test]
     fn test_string_from_error() {
-        let err = TMFError {
-            message : "ThisIsAnError".into(),
-        };
+        let err= TMFError::from("ThisIsAnError");
 
         let s : String = err.into();
         assert_eq!(s,"TMFError: ThisIsAnError".to_string());


### PR DESCRIPTION
# Details

- Converted TMFError into an enum, defining new error types
- Annotated TMFError with error messages
- Derived the Error Trait
- Updated unit tests
- Performed testing.