### PR TITLE
fix: create_tmf() now checks status code

### DIFF
--- a/examples/create_site.rs
+++ b/examples/create_site.rs
@@ -10,7 +10,7 @@ use tmflib::tmf674::geographic_site_v4::GeographicSite;
 fn main() -> Result<(),TMFError> {
     #[cfg(feature = "tmf674")]
     {
-        let site = GeographicSite::new("Example Site");
+        let site = GeographicSite::new("Example Bad Site");
 
         let new_site = TMFClient::new("https://localhost:8001")
             .tmf674()

--- a/examples/get_quote.rs
+++ b/examples/get_quote.rs
@@ -1,0 +1,25 @@
+use tmf_client::common::tmf_error::TMFError;
+#[cfg(feature = "tmf648")]
+use tmf_client::{Operations, TMFClient};
+
+
+fn main() -> Result<(),TMFError> {
+    #[cfg(feature = "tmf648")]
+    {
+        let mut client = TMFClient::new("https://localhost:8001");
+
+        let quotes = client
+            .tmf648()
+            .quote()
+            .list(None)?;
+    
+        for i in quotes {
+            use tmflib::{HasDescription, HasName};
+
+            println!("Name: {}, \tDesc: {}",&i.get_name(),i.get_description());
+        }
+    
+    }
+
+    Ok(())
+}

--- a/src/common/tmf_error.rs
+++ b/src/common/tmf_error.rs
@@ -37,6 +37,12 @@ impl From<serde_json::Error> for TMFError {
     }
 }
 
+impl From<std::io::Error> for TMFError {
+    fn from(value: std::io::Error) -> Self {
+        TMFError::NoConnection(value.to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/tmf/mod.rs
+++ b/src/tmf/mod.rs
@@ -85,9 +85,15 @@ pub fn create_tmf<T : HasId + Serialize + DeserializeOwned>(host : Uri, item : T
         .body(body_str)
         .send()?;
     let mut output = String::default();
-    let _ = res.read_to_string(&mut output);
-    let item : T = serde_json::from_str(output.as_str())?;
-    Ok(item)
+    let _count = res.read_to_string(&mut output)?;
+    match res.status() {
+        reqwest::StatusCode::CREATED | reqwest::StatusCode::OK => {
+            let item : T = serde_json::from_str(output.as_str())?;
+            Ok(item)
+        },
+        _ => return Err(TMFError::Unknown(format!("Failed to create TMF object: {}", output))),
+    }
+    
 }
 
 /// Update an existing TMF object


### PR DESCRIPTION
# Updates

- Match on status code after POST to return error if not successful.
- Support error conversion for reading response payload
- Added new example get_quote